### PR TITLE
Added command option.

### DIFF
--- a/bin/puppet-profiler
+++ b/bin/puppet-profiler
@@ -17,12 +17,16 @@ Basic Command Line Usage:
 Options:
 HELP
 
-options = {:number => 10}
+options = {:number => 10, :command => "puppet agent --test"}
 opts = OptionParser.new do |opts|
   opts.banner = help
 
-  opts.on('-n' '--number NUMBER', 'Number of results to return') do |v|
+  opts.on('-n', '--number NUMBER', "Number of results to return (default #{options[:number]})") do |v|
     options[:number] = v.to_i
+  end
+
+  opts.on('-c', '--command COMMAND', "Command to execute (default #{options[:command]})") do |v|
+    options[:command] = v.to_s
   end
 end
 
@@ -34,4 +38,4 @@ rescue OptionParser::InvalidOption
   exit 1
 end
 
-PuppetProfiler.run(options[:number])
+PuppetProfiler.run(options[:number], options[:command])

--- a/lib/puppet-profiler.rb
+++ b/lib/puppet-profiler.rb
@@ -1,6 +1,6 @@
 class PuppetProfiler
   def self.run(num_res, cmd)
-    cmd = cmd + " --evaltrace --color=false"
+    cmd = cmd + " --verbose --evaltrace --color=false"
     output = `#{cmd}`.split("\n")
 
     times = []

--- a/lib/puppet-profiler.rb
+++ b/lib/puppet-profiler.rb
@@ -1,6 +1,7 @@
 class PuppetProfiler
-  def self.run(num_res)
-    output = `puppet agent --test --evaltrace --color=false`.split("\n")
+  def self.run(num_res, cmd)
+    cmd = cmd + " --evaltrace --color=false"
+    output = `#{cmd}`.split("\n")
 
     times = []
     resources = output.select { |line| 


### PR DESCRIPTION
I added an option to specify the command.  This allows the use of puppet-profiler when testing local Puppet configurations (without pushing them to the puppetmaster) like this:

puppet-profiler --command "puppet apply --modulepath=... --external_nodes=... --node_terminus=exec --environment=development manifests/site.pp"
