### PR TITLE
Use regular expression instead of partititon and rpartition

### DIFF
--- a/lib/puppet-profiler.rb
+++ b/lib/puppet-profiler.rb
@@ -3,19 +3,13 @@ class PuppetProfiler
     output = `puppet agent --test --evaltrace --color=false`.split("\n")
 
     times = []
-    resources = output.select { |line| 
-      line =~ /.+: E?valuated in [\d\.]+ seconds$/
-    }.each { |line|
-      res_line, junk, eval_line = line.rpartition(':')
-      if eval_line =~ / E?valuated in ([\d\.]+) seconds$/
-        time = $1.to_f
-      end
-      junk, junk, res_line = res_line.partition(':')
-      if res_line =~ /.*([A-Z][^\[]+)\[(.+?)\]$/
+    output.each { |line|
+      if line =~ /info: .*([A-Z][^\[]+)\[(.+?)\]: Evaluated in ([\d\.]+) seconds$/
         type = $1
         title = $2
+        time = $3.to_f
+        times << [type, title, time]
       end
-      times << [type, title, time]
     }
 
     puts "Top #{num_res} Puppet resources by runtime"


### PR DESCRIPTION
I revised puppet-profiler to use a more complex regular expression instead of partititon and rpartition. This allows puppet-profiler to run on ruby 1.8.5, which does not have those methods. I've verified that it still runs correctly on Ruby 1.9.1.

While testing that my revision produced the same output as your implementation, I discovered that my regular expression fixes a bug handling info on recursive file resources. For some reason Puppet reports these twice, e.g.

info: /Stage[main]/Foo/File[/etc/httpd/conf/enabled_sites]: Evaluated in 0.00 seconds
info: /etc/httpd/conf/enabled_sites: Evaluated in 0.00 seconds

Without this revision, puppet-profiler outputs the second one as _0.0s - []_, since it matched the regular expression that sets _time_ but not the one that sets _type_ or _title_. With it, the second one is ignored.
