### PR TITLE
make regex case-insensitive

### DIFF
--- a/lib/puppet-profiler.rb
+++ b/lib/puppet-profiler.rb
@@ -5,7 +5,7 @@ class PuppetProfiler
 
     times = []
     output.each { |line|
-      if line =~ /info: .*([A-Z][^\[]+)\[(.+?)\]: Evaluated in ([\d\.]+) seconds$/
+      if line =~ /info: .*([A-Z][^\[]+)\[(.+?)\]: Evaluated in ([\d\.]+) seconds$/i
         type = $1
         title = $2
         time = $3.to_f


### PR DESCRIPTION
Current Puppet outputs the 'Info' tag with a capital but the regex has it all lowercase.  Added case-insensitive flag to the regex so it should work either way.

```
Info: Class[Puppet::Client::Bootstrapped]: Evaluated in 0.01 seconds
```
