### PR TITLE
regex match for Info or info

### DIFF
--- a/lib/puppet-profiler.rb
+++ b/lib/puppet-profiler.rb
@@ -5,7 +5,7 @@ class PuppetProfiler
 
     times = []
     output.each { |line|
-      if line =~ /info: .*([A-Z][^\[]+)\[(.+?)\]: Evaluated in ([\d\.]+) seconds$/
+      if line =~ /[Ii]nfo: .*([A-Z][^\[]+)\[(.+?)\]: Evaluated in ([\d\.]+) seconds$/
         type = $1
         title = $2
         time = $3.to_f


### PR DESCRIPTION
I'm running puppet 3.7.x and atleast with that, the `info` in the log output is actually `Info`. Since I wasn't sure if this had changed since previous versions, I've just updated the regex match to be `[Ii]nfo`
